### PR TITLE
Options are appended to command-line args after command

### DIFF
--- a/src/main/groovy/com/augusttechgroup/gradle/liquibase/tasks/LiquibaseBaseTask.groovy
+++ b/src/main/groovy/com/augusttechgroup/gradle/liquibase/tasks/LiquibaseBaseTask.groovy
@@ -55,12 +55,14 @@ class LiquibaseBaseTask extends DefaultTask {
       if(project.context) {
         args += "--contexts=${project.context}"
       }
+      
+      if (options) {
+        args += options
+      }
 
       if(command) {
         args += command
       }
-
-      args += (options ? options : [])
 
       println "Calling MAIN"
       Main.main(args as String[])


### PR DESCRIPTION
For example, if I add this to my build script:

updateSQL {
  options = ['--defaultSchemaName=SeansSchema']
}

it will generate arguments for com.augusttechgroup.gradle.liquibase.Main.main() with something like:

[--url=jdbc:..., ..., updateSQL, --defaultSchemaName=SeansSchema]

Actually, I think the command should always be the last argument:

[--url=jdbc:..., ..., --defaultSchemaName=SeansSchema, updateSQL]

The patch I'm sending you should order correctly.
