### PR TITLE
liquibase task fails with gradle 1.10

### DIFF
--- a/src/main/groovy/com/augusttechgroup/gradle/liquibase/LiquibaseTask.groovy
+++ b/src/main/groovy/com/augusttechgroup/gradle/liquibase/LiquibaseTask.groovy
@@ -62,7 +62,7 @@ class LiquibaseTask extends DefaultTask {
 	 * Build the proper command line and call Liquibase.
 	 * @param activity the activity holding the Liquibase particulars.
 	 */
-	private def runLiquibase(activity) {
+	def runLiquibase(activity) {
 		def args = []
 		activity.arguments.each {
 			args += "--${it.key}=${it.value}"


### PR DESCRIPTION
- What went wrong:
  Execution failed for task ':diff'.
  > No signature of method: com.augusttechgroup.gradle.liquibase.LiquibaseTask_Decorated.runLiquibase() is applicable for argument types: (com.augusttechgroup.gradle.liquibase.Activity) values: [com.aug
  usttechgroup.gradle.liquibase.Activity@3ef3aec8]
